### PR TITLE
appinfo.json: Add required icon field

### DIFF
--- a/application/appinfo.json
+++ b/application/appinfo.json
@@ -8,6 +8,7 @@
     "hidden": true,
     "type": "web",
     "noWindow": true,
+    "icon": "",
     "main": "validator.html",
     "title": "Libpurple Messaging Plugins Validator App",
     "requiredPermissions": ["activities.manage", "applications", "applications.internal", "database.internal", "services", "settings", "system"]


### PR DESCRIPTION
Fixes SAM appinfo.json schema validation error:

Apr 25 13:55:52 qemux86-64 sam[613]: [W][AppDescription][loadAppinfo][org.webosports.app.imvalidator] Failed to parse appinfo.json(/usr/palm/applications/org.webosports.app.imvalidator/appinfo.json)
Apr 25 13:55:52 qemux86-64 sam[613]: [W][AppDescription][scan][org.webosports.app.imvalidator] Cannot configure AppDescription
Apr 25 13:55:52 qemux86-64 sam[613]: [W][AppDescriptionList][scanDir][org.webosports.app.imvalidator] Cannot scan AppDescription

Signed-off-by: Herman van Hazendonk <github.com@herrie.org>